### PR TITLE
Correct code that will be forbidden in Rust 2021.

### DIFF
--- a/src/front/glsl/parser/preprocessor.rs
+++ b/src/front/glsl/parser/preprocessor.rs
@@ -347,7 +347,7 @@ pub fn preprocess(
                             error_token = lexer.next()
                         }
 
-                        panic!(error_message)
+                        panic!("{}", error_message)
                     }
                     "pragma" => {
                         let pragma_token = if token.line


### PR DESCRIPTION
In Rust 2021, the format string given to `panic!` must be a literal.
Rust 1.51 began warning about this.